### PR TITLE
fix: FWSS terminate CDN service call

### DIFF
--- a/src/FilBeamOperator.sol
+++ b/src/FilBeamOperator.sol
@@ -113,7 +113,7 @@ contract FilBeamOperator is Ownable {
     /// @dev Can only be called by the FilBeam operator controller
     /// @param dataSetId The data set ID to terminate payment rails for
     function terminateCDNPaymentRails(uint256 dataSetId) external onlyFilBeamOperatorController {
-        IFWSS(fwssContractAddress).terminateCDNPaymentRails(dataSetId);
+        IFWSS(fwssContractAddress).terminateCDNService(dataSetId);
 
         emit PaymentRailsTerminated(dataSetId);
     }

--- a/src/interfaces/IFWSS.sol
+++ b/src/interfaces/IFWSS.sol
@@ -19,7 +19,7 @@ interface IFWSS {
 
     function settleFilBeamPaymentRails(uint256 dataSetId, uint256 cdnAmount, uint256 cacheMissAmount) external;
 
-    function terminateCDNPaymentRails(uint256 dataSetId) external;
+    function terminateCDNService(uint256 dataSetId) external;
 
     function usdfcTokenAddress() external view returns (address);
 

--- a/src/mocks/MockFWSS.sol
+++ b/src/mocks/MockFWSS.sol
@@ -58,7 +58,7 @@ contract MockFWSS is IFWSS {
         emit PaymentRailsSettled(dataSetId, cdnAmount, cacheMissAmount);
     }
 
-    function terminateCDNPaymentRails(uint256 dataSetId) external onlyAuthorized {
+    function terminateCDNService(uint256 dataSetId) external onlyAuthorized {
         terminatedDataSets[dataSetId] = true;
         emit PaymentRailsTerminated(dataSetId);
     }


### PR DESCRIPTION
Fixes call to FWSS where FilBeamOperator is calling `FWSS.terminateCDNPaymentRails` instead of `FWSS.terminateCDNService`.