### PR TITLE
chore: Use two step ownership transfer

### DIFF
--- a/src/FilBeamOperator.sol
+++ b/src/FilBeamOperator.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.13;
 
 import "./Errors.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable, Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {FilecoinPayV1} from "@filecoin-pay/FilecoinPayV1.sol";
 import {FilecoinWarmStorageService} from "@filecoin-services/FilecoinWarmStorageService.sol";
 import {FilecoinWarmStorageServiceStateView} from "@filecoin-services/FilecoinWarmStorageServiceStateView.sol";
 
-contract FilBeamOperator is Ownable {
+contract FilBeamOperator is Ownable2Step {
     struct DataSetUsage {
         uint256 cdnAmount;
         uint256 cacheMissAmount;

--- a/test/FilBeamOperator.t.sol
+++ b/test/FilBeamOperator.t.sol
@@ -448,11 +448,22 @@ contract FilBeamOperatorTest is Test {
     }
 
     function test_TransferOwnership() public {
+        assertEq(filBeam.owner(), owner);
+
+        vm.prank(owner);
         filBeam.transferOwnership(user1);
+        assertEq(filBeam.pendingOwner(), user1);
+
+        vm.prank(user1);
+        filBeam.acceptOwnership();
         assertEq(filBeam.owner(), user1);
 
         vm.prank(user1);
         filBeam.transferOwnership(user2);
+        assertEq(filBeam.pendingOwner(), user2);
+
+        vm.prank(user2);
+        filBeam.acceptOwnership();
         assertEq(filBeam.owner(), user2);
     }
 
@@ -460,11 +471,6 @@ contract FilBeamOperatorTest is Test {
         vm.prank(user1);
         vm.expectRevert();
         filBeam.transferOwnership(user2);
-    }
-
-    function test_TransferOwnershipRevertZeroAddress() public {
-        vm.expectRevert();
-        filBeam.transferOwnership(address(0));
     }
 
     function test_MultipleDataSets() public {


### PR DESCRIPTION
Replaces `Ownable` with `Ownable2Step` contract which should prevent the issue of ownership transfer to an invalid or non-existing address. 