### PR TITLE
Add GitHub Actions workflow for ABI release

### DIFF
--- a/.github/workflows/abi-release.yml
+++ b/.github/workflows/abi-release.yml
@@ -9,8 +9,6 @@ jobs:
   release-abi:
     name: Release ABI
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - name: Checkout repository
@@ -28,11 +26,11 @@ jobs:
         run: |
           mkdir -p abis
           jq '.abi' out/FilBeamOperator.sol/FilBeamOperator.json \
-          > abis/FilBeamOperator.abi.json
+            > abis/FilBeamOperator.abi.json
 
       - name: Publish ABIs to GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v6
+        uses: softprops/action-gh-release@v2
         with:
-          name: abis-${{ github.ref_name }}
-          path: abis/**
+          tag_name: ${{ github.ref_name }}
+          files: |
+            abis/**

--- a/.github/workflows/abi-release.yml
+++ b/.github/workflows/abi-release.yml
@@ -34,5 +34,5 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v6
         with:
-          tag: ${{ github.ref_name }}
-          artifacts: abis/**
+          name: abis-${{ github.ref_name }}
+          path: abis/**

--- a/.github/workflows/abi-release.yml
+++ b/.github/workflows/abi-release.yml
@@ -1,0 +1,38 @@
+name: ABI Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release-abi:
+    name: Release ABI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Build contracts
+        run: forge build
+
+      - name: Extract ABIs
+        run: |
+          mkdir -p abis
+          jq '.abi' out/FilBeamOperator.sol/FilBeamOperator.json \
+          > abis/FilBeamOperator.abi.json
+
+      - name: Publish ABIs to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ github.ref_name }}
+          artifacts: abis/**

--- a/.github/workflows/abi-release.yml
+++ b/.github/workflows/abi-release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Publish ABIs to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: ncipollo/release-action@v1
+        uses: actions/upload-artifact@v6
         with:
           tag: ${{ github.ref_name }}
           artifacts: abis/**


### PR DESCRIPTION
Fixes #12 

This workflow creates a new release when a new tag is pushed and adds abi of the contract as an artifact to the release 