### PR TITLE
feat: settle CDN bandwidth per shared rail (subscription)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ function setFilBeamOperatorController(address _filBeamOperatorController) extern
 - **Partial Settlements**: Supports partial settlements when accumulated amount exceeds payment rail's `lockupFixed`
 
 ### Rail Settlement 
-- **Independent Tracking**: CDN and cache-miss settlements tracked separately
-- **Epoch-Based**: Settlement periods defined by epoch ranges
+- **Independent Tracking**: CDN (bandwidth) and cache-miss settlements tracked separately
+- **Shared Bandwidth Rail**: Bandwidth is accumulated and settled per `cdnRailId` (the CDN subscription identity). Datasets that share a subscription resolve to the same `cdnRailId` and settle bandwidth once with the summed amount via `settleCDNBandwidthRail`
+- **Per-Dataset Cache-Miss**: Cache-miss is accumulated and settled per `dataSetId` via `settleFilBeamPaymentRails(dataSetId, 0, cacheMissAmount)`
 - **Accumulative**: Usage accumulates between settlements
 
 ## SP Settlement Tooling

--- a/SPEC.md
+++ b/SPEC.md
@@ -24,12 +24,12 @@ The Filecoin Beam (FilBeamOperator) contract is responsible for managing CDN (ca
 - FilBeamOperator controller cannot be zero address
 
 #### Data Structure
-**DataSetUsage Struct**:
-- `uint256 cdnAmount`: Accumulated CDN settlement amount between settlements (calculated at report time)
+**DataSetUsage Struct** (cache-miss accounting, keyed by `dataSetId`):
 - `uint256 cacheMissAmount`: Accumulated cache-miss settlement amount between settlements (calculated at report time)
 - `uint256 maxReportedEpoch`: Highest epoch number reported for this dataset (0 indicates uninitialized dataset)
-- `uint256 lastCDNSettlementEpoch`: Last epoch settled for CDN payment rail
-- `uint256 lastCacheMissSettlementEpoch`: Last epoch settled for cache-miss payment rail
+
+**Shared bandwidth accounting** (keyed by `cdnRailId`):
+- `mapping(uint256 cdnRailId => uint256 cdnAmount) cdnRailAmount`: Accumulated CDN (bandwidth) settlement amount between settlements, keyed by the shared bandwidth rail. Multiple datasets that belong to one CDN subscription resolve to the same `cdnRailId` (read from `FilecoinWarmStorageServiceStateView.getDataSet(dataSetId).cdnRailId`), so their bandwidth aggregates onto a single rail.
 
 #### Usage Reporting
 
@@ -61,28 +61,33 @@ The Filecoin Beam (FilBeamOperator) contract is responsible for managing CDN (ca
 
 #### Payment Rail Settlement
 
+**Method**: `settleCDNBandwidthRails(uint256[] cdnRailIds)`
+
+- **Access**: Publicly callable (anyone can trigger settlement)
+- **Purpose**: Canonical bandwidth settlement path. Settles shared CDN bandwidth rails directly by rail id, the shared `cdnRailId` is the subscription identity. The FilBeam worker meters bandwidth per rail and calls this with the distinct rail ids.
+- **Settlement Logic**: For each rail id, reads `cdnRailAmount[cdnRailId]`, settles `min(accumulated, rail.lockupFixed)` via FWSS `settleCDNBandwidthRail(cdnRailId, amount)`, and drains the settled amount. Skips rails with no accumulated bandwidth or no lockup.
+- **Events**: Emits `CDNSettlement(cdnRailId, cdnAmount)` with the actual settled amount.
+
 **Method**: `settleCDNPaymentRails(uint256[] dataSetIds)`
 
 - **Access**: Publicly callable (anyone can trigger settlement)
-- **Purpose**: Settles CDN payment rails for multiple datasets in a single transaction
-- **Calculation Period**: From last CDN settlement epoch + 1 to max reported epoch
+- **Purpose**: Convenience path equivalent to `settleCDNBandwidthRails`, but resolves each dataset to its shared `cdnRailId` first. Prefer `settleCDNBandwidthRails` when the rail ids are already known.
 - **Settlement Logic**:
-  - Retrieves rail ID from FWSS DataSetInfo
+  - Resolves each dataset to its shared `cdnRailId` via `FilecoinWarmStorageServiceStateView.getDataSet(dataSetId).cdnRailId`
+  - Reads the aggregated bandwidth accumulated on that rail (`cdnRailAmount[cdnRailId]`)
   - Fetches rail details from Payments contract to get `lockupFixed`
   - Calculates settleable amount: `min(accumulated_amount, rail.lockupFixed)`
-  - Only calls FWSS contract if settleable amount > 0
+  - Only calls FWSS `settleCDNBandwidthRail(cdnRailId, amount)` if settleable amount > 0
   - Reduces accumulated CDN amount by settled amount (may leave remainder)
-- **State Updates**:
-  - Update last CDN settlement epoch to max reported epoch
-  - Reduce accumulated amount by settled amount (not reset to zero if partial)
+- **Settle Once Per Rail**: Because grouped datasets share a `cdnRailId`, bandwidth is settled once per distinct rail with the summed amount. The rail balance is drained on the first settlement, so later datasets that share the same rail within the same call (or a later call) are skipped automatically.
 - **Requirements**: None - gracefully skips datasets that cannot be settled
 - **Batch Processing**:
   - Processes each dataset independently (non-reverting)
-  - Skips uninitialized datasets or those without new usage
-  - Skips datasets without valid rail configuration
+  - Skips datasets whose shared rail has no accumulated bandwidth
+  - Skips datasets without a configured `cdnRailId` (rail id 0)
   - Continues processing even if some datasets cannot be settled
 - **Partial Settlement**: Supports partial settlements when `accumulated_amount > lockupFixed`
-- **Events**: Emits `CDNSettlement` event with actual settled amount (may be less than accumulated)
+- **Events**: Emits `CDNSettlement(cdnRailId, cdnAmount)` with the actual settled amount (may be less than accumulated)
 - **Independent Operation**: Can be called independently of cache-miss settlement
 
 **Method**: `settleCacheMissPaymentRails(uint256[] dataSetIds)`
@@ -160,8 +165,8 @@ The Filecoin Beam (FilBeamOperator) contract is responsible for managing CDN (ca
 
 #### Events
 - `UsageReported(uint256 indexed dataSetId, uint256 indexed fromEpoch, uint256 indexed toEpoch, uint256 cdnBytesUsed, uint256 cacheMissBytesUsed)`
-- `CDNSettlement(uint256 indexed dataSetId, uint256 fromEpoch, uint256 toEpoch, uint256 cdnAmount)`
-- `CacheMissSettlement(uint256 indexed dataSetId, uint256 fromEpoch, uint256 toEpoch, uint256 cacheMissAmount)`
+- `CDNSettlement(uint256 indexed cdnRailId, uint256 cdnAmount)` (keyed by the shared bandwidth rail)
+- `CacheMissSettlement(uint256 indexed dataSetId, uint256 cacheMissAmount)` (keyed by data set)
 - `PaymentRailsTerminated(uint256 indexed dataSetId)`
 - `FilBeamOperatorControllerUpdated(address indexed oldController, address indexed newController)`
 - `FwssFilBeamControllerMigrated(address indexed previousController, address indexed newController)`
@@ -181,9 +186,14 @@ The Filecoin Beam (FilBeamOperator) contract is responsible for managing CDN (ca
 ### Filecoin Warm Storage Service (FWSS) Contract Interface
 
 **Method**: `settleFilBeamPaymentRails(uint256 dataSetId, uint256 cdnAmount, uint256 cacheMissAmount)`
-- **Purpose**: Settle CDN or cache-miss payment rails based on calculated amounts
+- **Purpose**: Settle the per-dataset cache-miss payment rail
 - **Access**: Callable only by FilBeamOperator contract
-- **Parameters**: Either cdnAmount or cacheMissAmount will be zero depending on settlement type
+- **Parameters**: FilBeamOperator always passes `cdnAmount = 0` so the bandwidth portion is never settled through this per-dataset path (it is settled through `settleCDNBandwidthRail` instead)
+
+**Method**: `settleCDNBandwidthRail(uint256 cdnRailId, uint256 cdnAmount)`
+- **Purpose**: Settle the shared CDN (bandwidth) payment rail once for a subscription
+- **Access**: Callable only by FilBeamOperator contract
+- **Parameters**: `cdnRailId` is the shared bandwidth rail (subscription identity), `cdnAmount` is the aggregated bandwidth across every dataset sharing that rail
 
 **Method**: `terminateCDNPaymentRails(uint256 dataSetId)`
 - **Purpose**: Terminate CDN payment rails for a specific dataset

--- a/src/FilBeamOperator.sol
+++ b/src/FilBeamOperator.sol
@@ -7,9 +7,18 @@ import {FilecoinPayV1} from "@filecoin-pay/FilecoinPayV1.sol";
 import {FilecoinWarmStorageService} from "@filecoin-services/FilecoinWarmStorageService.sol";
 import {FilecoinWarmStorageServiceStateView} from "@filecoin-services/FilecoinWarmStorageServiceStateView.sol";
 
+/// @notice Minimal interface for the shared CDN bandwidth rail settlement added in FWSS.
+/// @dev The shared bandwidth rail is keyed by cdnRailId (the subscription identity), so it is
+/// settled once per rail rather than per data set. Cache miss continues to be settled per data
+/// set via FilecoinWarmStorageService.settleFilBeamPaymentRails.
+interface IFilBeamBandwidthSettlement {
+    function settleCDNBandwidthRail(uint256 cdnRailId, uint256 cdnAmount) external;
+}
+
 contract FilBeamOperator is Ownable2Step {
+    /// @notice Cache miss usage accounting, keyed by dataSetId.
+    /// @dev Cache miss rails stay per data set because each copy lives on a different provider.
     struct DataSetUsage {
-        uint256 cdnAmount;
         uint256 cacheMissAmount;
         uint256 maxReportedEpoch;
     }
@@ -21,7 +30,12 @@ contract FilBeamOperator is Ownable2Step {
     uint256 public immutable cacheMissRatePerByte;
     address public filBeamOperatorController;
 
-    mapping(uint256 => DataSetUsage) public dataSetUsage;
+    /// @notice Cache miss usage accumulated per data set between settlements.
+    mapping(uint256 dataSetId => DataSetUsage) public dataSetUsage;
+
+    /// @notice CDN (bandwidth) usage accumulated per shared bandwidth rail between settlements.
+    /// @dev Keyed by cdnRailId so data sets sharing a CDN subscription collapse into one rail.
+    mapping(uint256 cdnRailId => uint256 cdnAmount) public cdnRailAmount;
 
     event UsageReported(
         uint256 indexed dataSetId,
@@ -31,7 +45,7 @@ contract FilBeamOperator is Ownable2Step {
         uint256 cacheMissBytesUsed
     );
 
-    event CDNSettlement(uint256 indexed dataSetId, uint256 cdnAmount);
+    event CDNSettlement(uint256 indexed cdnRailId, uint256 cdnAmount);
 
     event CacheMissSettlement(uint256 indexed dataSetId, uint256 cacheMissAmount);
 
@@ -97,12 +111,26 @@ contract FilBeamOperator is Ownable2Step {
         }
     }
 
-    /// @notice Settles CDN payment rails for multiple data sets
-    /// @dev Anyone can call this function to trigger settlement
-    /// @param dataSetIds Array of data set IDs to settle
+    /// @notice Settles shared CDN bandwidth rails directly by rail id.
+    /// @dev Canonical bandwidth settlement path: the shared cdnRailId is the subscription identity,
+    /// so each rail is settled once with its aggregated amount. The FilBeam worker calls this with
+    /// the distinct cdnRailIds it has metered. Anyone can call it to trigger settlement.
+    /// @param cdnRailIds Array of shared CDN bandwidth rail ids to settle
+    function settleCDNBandwidthRails(uint256[] calldata cdnRailIds) external {
+        for (uint256 i = 0; i < cdnRailIds.length; i++) {
+            _settleCDNBandwidthRailById(cdnRailIds[i]);
+        }
+    }
+
+    /// @notice Settles the shared CDN bandwidth rails for multiple data sets.
+    /// @dev Convenience path that resolves each data set to its shared cdnRailId and settles once
+    /// per distinct rail with the aggregated amount. Because the rail balance is drained on the
+    /// first settlement, later data sets that share the same rail in this batch are skipped. Prefer
+    /// settleCDNBandwidthRails when the rail ids are already known. Anyone can call this.
+    /// @param dataSetIds Array of data set IDs whose shared bandwidth rails should be settled
     function settleCDNPaymentRails(uint256[] calldata dataSetIds) external {
         for (uint256 i = 0; i < dataSetIds.length; i++) {
-            _settlePaymentRail(dataSetIds[i], true);
+            _settleCDNBandwidthRail(dataSetIds[i]);
         }
     }
 
@@ -111,7 +139,7 @@ contract FilBeamOperator is Ownable2Step {
     /// @param dataSetIds Array of data set IDs to settle
     function settleCacheMissPaymentRails(uint256[] calldata dataSetIds) external {
         for (uint256 i = 0; i < dataSetIds.length; i++) {
-            _settlePaymentRail(dataSetIds[i], false);
+            _settleCacheMissRail(dataSetIds[i]);
         }
     }
 
@@ -169,21 +197,62 @@ contract FilBeamOperator is Ownable2Step {
         uint256 cdnAmount = cdnBytesUsed * cdnRatePerByte;
         uint256 cacheMissAmount = cacheMissBytesUsed * cacheMissRatePerByte;
 
-        usage.cdnAmount += cdnAmount;
+        // Cache miss accumulates per data set, bandwidth accumulates onto the shared CDN rail
+        // so grouped data sets aggregate into a single bandwidth settlement.
+        uint256 cdnRailId =
+            FilecoinWarmStorageServiceStateView(fwssStateViewContractAddress).getDataSet(dataSetId).cdnRailId;
+        cdnRailAmount[cdnRailId] += cdnAmount;
+
         usage.cacheMissAmount += cacheMissAmount;
         usage.maxReportedEpoch = toEpoch;
 
         emit UsageReported(dataSetId, fromEpoch, toEpoch, cdnBytesUsed, cacheMissBytesUsed);
     }
 
-    /// @dev Internal function to settle a payment rail (CDN or cache miss)
+    /// @dev Resolves a data set to its shared bandwidth rail (the subscription identity) and settles it
+    /// @param dataSetId The data set ID whose shared bandwidth rail should be settled
+    function _settleCDNBandwidthRail(uint256 dataSetId) internal {
+        uint256 cdnRailId =
+            FilecoinWarmStorageServiceStateView(fwssStateViewContractAddress).getDataSet(dataSetId).cdnRailId;
+        _settleCDNBandwidthRailById(cdnRailId);
+    }
+
+    /// @dev Settles a shared CDN bandwidth rail once with its aggregated amount
+    /// @param cdnRailId The shared bandwidth rail id (subscription identity)
+    function _settleCDNBandwidthRailById(uint256 cdnRailId) internal {
+        // Early return if no rail configured
+        if (cdnRailId == 0) {
+            return;
+        }
+
+        // Aggregated bandwidth across every data set sharing this rail
+        uint256 amount = cdnRailAmount[cdnRailId];
+
+        // Early return if no usage to settle (also collapses repeated rails in a batch)
+        if (amount == 0) {
+            return;
+        }
+
+        // Get the actual amount we can settle based on rail lockup
+        uint256 amountToSettle = _getSettleableAmount(cdnRailId, amount);
+
+        // Early return if nothing can be settled (no lockup available)
+        if (amountToSettle == 0) {
+            return;
+        }
+
+        // Settle the shared bandwidth rail once through FWSS
+        IFilBeamBandwidthSettlement(fwssContractAddress).settleCDNBandwidthRail(cdnRailId, amountToSettle);
+        cdnRailAmount[cdnRailId] -= amountToSettle;
+        emit CDNSettlement(cdnRailId, amountToSettle);
+    }
+
+    /// @dev Internal function to settle the cache miss rail for a data set
     /// @param dataSetId The data set ID to settle
-    /// @param isCDN True for CDN rail, false for cache miss rail
-    function _settlePaymentRail(uint256 dataSetId, bool isCDN) internal {
+    function _settleCacheMissRail(uint256 dataSetId) internal {
         DataSetUsage storage usage = dataSetUsage[dataSetId];
 
-        // Get the appropriate amount based on rail type
-        uint256 amount = isCDN ? usage.cdnAmount : usage.cacheMissAmount;
+        uint256 amount = usage.cacheMissAmount;
 
         // Early return if data set not initialized or no usage to settle
         if (usage.maxReportedEpoch == 0 || amount == 0) {
@@ -191,9 +260,8 @@ contract FilBeamOperator is Ownable2Step {
         }
 
         // Get rail ID from FWSS State View
-        FilecoinWarmStorageService.DataSetInfoView memory dsInfo =
-            FilecoinWarmStorageServiceStateView(fwssStateViewContractAddress).getDataSet(dataSetId);
-        uint256 railId = isCDN ? dsInfo.cdnRailId : dsInfo.cacheMissRailId;
+        uint256 railId =
+            FilecoinWarmStorageServiceStateView(fwssStateViewContractAddress).getDataSet(dataSetId).cacheMissRailId;
 
         // Early return if no rail configured
         if (railId == 0) {
@@ -208,16 +276,11 @@ contract FilBeamOperator is Ownable2Step {
             return;
         }
 
-        // Settle the amount through FWSS
-        if (isCDN) {
-            FilecoinWarmStorageService(fwssContractAddress).settleFilBeamPaymentRails(dataSetId, amountToSettle, 0);
-            usage.cdnAmount -= amountToSettle;
-            emit CDNSettlement(dataSetId, amountToSettle);
-        } else {
-            FilecoinWarmStorageService(fwssContractAddress).settleFilBeamPaymentRails(dataSetId, 0, amountToSettle);
-            usage.cacheMissAmount -= amountToSettle;
-            emit CacheMissSettlement(dataSetId, amountToSettle);
-        }
+        // Settle cache miss per data set. cdnAmount is 0 so the bandwidth portion is never
+        // settled through the per-data-set path (it goes through settleCDNBandwidthRail instead).
+        FilecoinWarmStorageService(fwssContractAddress).settleFilBeamPaymentRails(dataSetId, 0, amountToSettle);
+        usage.cacheMissAmount -= amountToSettle;
+        emit CacheMissSettlement(dataSetId, amountToSettle);
     }
 
     /// @dev Internal helper to get the settleable amount based on rail lockup

--- a/src/mocks/MockFWSS.sol
+++ b/src/mocks/MockFWSS.sol
@@ -9,13 +9,21 @@ contract MockFWSS {
         uint256 timestamp;
     }
 
+    struct BandwidthSettlement {
+        uint256 cdnRailId;
+        uint256 cdnAmount;
+        uint256 timestamp;
+    }
+
     Settlement[] public settlements;
+    BandwidthSettlement[] public bandwidthSettlements;
     mapping(uint256 => bool) public terminatedDataSets;
     address public authorizedCaller;
     address public usdfcTokenAddress;
     address public paymentsContractAddress;
 
     event PaymentRailsSettled(uint256 indexed dataSetId, uint256 cdnAmount, uint256 cacheMissAmount);
+    event CDNBandwidthRailSettled(uint256 indexed cdnRailId, uint256 cdnAmount);
     event PaymentRailsTerminated(uint256 indexed dataSetId);
     event FilBeamControllerChanged(address indexed oldController, address indexed newController);
 
@@ -55,6 +63,14 @@ contract MockFWSS {
         emit PaymentRailsSettled(dataSetId, cdnAmount, cacheMissAmount);
     }
 
+    function settleCDNBandwidthRail(uint256 cdnRailId, uint256 cdnAmount) external onlyAuthorized {
+        bandwidthSettlements.push(
+            BandwidthSettlement({cdnRailId: cdnRailId, cdnAmount: cdnAmount, timestamp: block.timestamp})
+        );
+
+        emit CDNBandwidthRailSettled(cdnRailId, cdnAmount);
+    }
+
     function terminateCDNService(uint256 dataSetId) external onlyAuthorized {
         terminatedDataSets[dataSetId] = true;
         emit PaymentRailsTerminated(dataSetId);
@@ -71,6 +87,19 @@ contract MockFWSS {
     {
         Settlement storage settlement = settlements[index];
         return (settlement.dataSetId, settlement.cdnAmount, settlement.cacheMissAmount, settlement.timestamp);
+    }
+
+    function getBandwidthSettlementsCount() external view returns (uint256) {
+        return bandwidthSettlements.length;
+    }
+
+    function getBandwidthSettlement(uint256 index)
+        external
+        view
+        returns (uint256 cdnRailId, uint256 cdnAmount, uint256 timestamp)
+    {
+        BandwidthSettlement storage settlement = bandwidthSettlements[index];
+        return (settlement.cdnRailId, settlement.cdnAmount, settlement.timestamp);
     }
 
     function transferFilBeamController(address newController) external onlyAuthorized {

--- a/test/FilBeamOperator.t.sol
+++ b/test/FilBeamOperator.t.sol
@@ -22,6 +22,10 @@ contract FilBeamOperatorTest is Test {
 
     uint256 constant DATA_SET_ID_1 = 1;
     uint256 constant DATA_SET_ID_2 = 2;
+    uint256 constant CDN_RAIL_ID_1 = 1;
+    uint256 constant CACHE_MISS_RAIL_ID_1 = 2;
+    uint256 constant CDN_RAIL_ID_2 = 3;
+    uint256 constant CACHE_MISS_RAIL_ID_2 = 4;
     uint256 constant CDN_RATE_PER_BYTE = 100;
     uint256 constant CACHE_MISS_RATE_PER_BYTE = 200;
 
@@ -33,7 +37,7 @@ contract FilBeamOperatorTest is Test {
         uint256 cacheMissBytesUsed
     );
 
-    event CDNSettlement(uint256 indexed dataSetId, uint256 cdnAmount);
+    event CDNSettlement(uint256 indexed cdnRailId, uint256 cdnAmount);
 
     event CacheMissSettlement(uint256 indexed dataSetId, uint256 cacheMissAmount);
 
@@ -265,9 +269,9 @@ contract FilBeamOperatorTest is Test {
             1, _singleUint256Array(DATA_SET_ID_1), _singleUint256Array(1000), _singleUint256Array(500)
         );
 
-        (uint256 cdnAmount, uint256 cacheMissAmount, uint256 maxReportedEpoch) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        (uint256 cacheMissAmount, uint256 maxReportedEpoch) = filBeam.dataSetUsage(DATA_SET_ID_1);
 
-        assertEq(cdnAmount, 1000 * CDN_RATE_PER_BYTE);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 1000 * CDN_RATE_PER_BYTE);
         assertEq(cacheMissAmount, 500 * CACHE_MISS_RATE_PER_BYTE);
         assertEq(maxReportedEpoch, 1);
     }
@@ -285,9 +289,9 @@ contract FilBeamOperatorTest is Test {
         );
         vm.stopPrank();
 
-        (uint256 cdnAmount, uint256 cacheMissAmount, uint256 maxReportedEpoch) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        (uint256 cacheMissAmount, uint256 maxReportedEpoch) = filBeam.dataSetUsage(DATA_SET_ID_1);
 
-        assertEq(cdnAmount, 4500 * CDN_RATE_PER_BYTE);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 4500 * CDN_RATE_PER_BYTE);
         assertEq(cacheMissAmount, 2250 * CACHE_MISS_RATE_PER_BYTE);
         assertEq(maxReportedEpoch, 3);
     }
@@ -345,22 +349,47 @@ contract FilBeamOperatorTest is Test {
         vm.stopPrank();
 
         vm.expectEmit(true, false, false, true);
-        emit CDNSettlement(DATA_SET_ID_1, 300000);
+        emit CDNSettlement(CDN_RAIL_ID_1, 300000);
 
         vm.prank(user1);
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
-        (uint256 cdnAmount, uint256 cacheMissAmount, uint256 maxReportedEpoch) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        (uint256 cacheMissAmount, uint256 maxReportedEpoch) = filBeam.dataSetUsage(DATA_SET_ID_1);
 
-        assertEq(cdnAmount, 0);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 0);
         assertEq(cacheMissAmount, 1500 * CACHE_MISS_RATE_PER_BYTE);
         assertEq(maxReportedEpoch, 2);
 
-        assertEq(mockFWSS.getSettlementsCount(), 1);
-        (uint256 dataSetId, uint256 settledCdnAmount, uint256 settledCacheMissAmount,) = mockFWSS.getSettlement(0);
-        assertEq(dataSetId, DATA_SET_ID_1);
+        // Bandwidth settles via the shared-rail path, not the per-data-set path
+        assertEq(mockFWSS.getSettlementsCount(), 0);
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1);
+        (uint256 cdnRailId, uint256 settledCdnAmount,) = mockFWSS.getBandwidthSettlement(0);
+        assertEq(cdnRailId, CDN_RAIL_ID_1);
         assertEq(settledCdnAmount, 300000);
-        assertEq(settledCacheMissAmount, 0);
+    }
+
+    function test_SettleCDNBandwidthRailsByRailId() public {
+        vm.startPrank(filBeamOperatorController);
+        filBeam.recordUsageRollups(
+            1, _singleUint256Array(DATA_SET_ID_1), _singleUint256Array(1000), _singleUint256Array(500)
+        );
+        filBeam.recordUsageRollups(
+            2, _singleUint256Array(DATA_SET_ID_1), _singleUint256Array(2000), _singleUint256Array(1000)
+        );
+        vm.stopPrank();
+
+        vm.expectEmit(true, false, false, true);
+        emit CDNSettlement(CDN_RAIL_ID_1, 300000);
+
+        // Canonical path: settle by rail id directly (what the FilBeam worker calls)
+        vm.prank(user1);
+        filBeam.settleCDNBandwidthRails(_singleUint256Array(CDN_RAIL_ID_1));
+
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 0);
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1);
+        (uint256 cdnRailId, uint256 settledCdnAmount,) = mockFWSS.getBandwidthSettlement(0);
+        assertEq(cdnRailId, CDN_RAIL_ID_1);
+        assertEq(settledCdnAmount, 300000);
     }
 
     function test_SettleCacheMissPaymentRail() public {
@@ -379,9 +408,9 @@ contract FilBeamOperatorTest is Test {
         vm.prank(user1);
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
-        (uint256 cdnAmount, uint256 cacheMissAmount, uint256 maxReportedEpoch) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        (uint256 cacheMissAmount, uint256 maxReportedEpoch) = filBeam.dataSetUsage(DATA_SET_ID_1);
 
-        assertEq(cdnAmount, 3000 * CDN_RATE_PER_BYTE);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 3000 * CDN_RATE_PER_BYTE);
         assertEq(cacheMissAmount, 0);
         assertEq(maxReportedEpoch, 2);
 
@@ -407,18 +436,18 @@ contract FilBeamOperatorTest is Test {
             1, _singleUint256Array(DATA_SET_ID_1), _singleUint256Array(1000), _singleUint256Array(500)
         );
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        assertEq(mockFWSS.getSettlementsCount(), 1);
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1);
 
         // Should not revert, just return early without additional settlements
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        assertEq(mockFWSS.getSettlementsCount(), 1); // Still 1, no new settlement
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1); // Still 1, no new settlement
 
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        assertEq(mockFWSS.getSettlementsCount(), 2);
+        assertEq(mockFWSS.getSettlementsCount(), 1);
 
         // Should not revert, just return early without additional settlements
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        assertEq(mockFWSS.getSettlementsCount(), 2); // Still 2, no new settlement
+        assertEq(mockFWSS.getSettlementsCount(), 1); // Still 1, no new settlement
     }
 
     function test_TerminateCDNPaymentRails() public {
@@ -486,16 +515,16 @@ contract FilBeamOperatorTest is Test {
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_2));
 
-        assertEq(mockFWSS.getSettlementsCount(), 2);
-
-        (uint256 settledDataSetId1, uint256 settledCdnAmount1, uint256 settledCacheMissAmount1,) =
-            mockFWSS.getSettlement(0);
-        assertEq(settledDataSetId1, DATA_SET_ID_1);
+        // DS1 bandwidth settles via the shared-rail path
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1);
+        (uint256 settledCdnRailId, uint256 settledCdnAmount1,) = mockFWSS.getBandwidthSettlement(0);
+        assertEq(settledCdnRailId, CDN_RAIL_ID_1);
         assertEq(settledCdnAmount1, 100000);
-        assertEq(settledCacheMissAmount1, 0);
 
+        // DS2 cache miss settles per data set
+        assertEq(mockFWSS.getSettlementsCount(), 1);
         (uint256 settledDataSetId2, uint256 settledCdnAmount2, uint256 settledCacheMissAmount2,) =
-            mockFWSS.getSettlement(1);
+            mockFWSS.getSettlement(0);
         assertEq(settledDataSetId2, DATA_SET_ID_2);
         assertEq(settledCdnAmount2, 0);
         assertEq(settledCacheMissAmount2, 200000);
@@ -518,9 +547,10 @@ contract FilBeamOperatorTest is Test {
         );
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
-        assertEq(mockFWSS.getSettlementsCount(), 2);
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1);
+        assertEq(mockFWSS.getSettlementsCount(), 1);
 
-        (,, uint256 maxReportedEpoch) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        (, uint256 maxReportedEpoch) = filBeam.dataSetUsage(DATA_SET_ID_1);
         assertEq(maxReportedEpoch, 3);
     }
 
@@ -537,9 +567,12 @@ contract FilBeamOperatorTest is Test {
             epoch, _singleUint256Array(dataSetId), _singleUint256Array(cdnBytes), _singleUint256Array(cacheMissBytes)
         );
 
-        (uint256 cdnAmount, uint256 cacheMissAmount, uint256 maxReportedEpoch) = filBeam.dataSetUsage(dataSetId);
+        (uint256 cacheMissAmount, uint256 maxReportedEpoch) = filBeam.dataSetUsage(dataSetId);
 
-        assertEq(cdnAmount, cdnBytes * CDN_RATE_PER_BYTE);
+        // Fuzzed data sets are not configured in the mock state view, so they resolve to
+        // cdnRailId 0 and bandwidth accumulates onto that rail.
+        uint256 cdnRailId = mockStateView.getDataSet(dataSetId).cdnRailId;
+        assertEq(filBeam.cdnRailAmount(cdnRailId), cdnBytes * CDN_RATE_PER_BYTE);
         assertEq(cacheMissAmount, cacheMissBytes * CACHE_MISS_RATE_PER_BYTE);
         assertEq(maxReportedEpoch, epoch);
     }
@@ -554,7 +587,7 @@ contract FilBeamOperatorTest is Test {
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
         // No external call should be made when amount is 0
-        assertEq(mockFWSS.getSettlementsCount(), 0);
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 0);
     }
 
     function test_IndependentSettlement() public {
@@ -572,7 +605,7 @@ contract FilBeamOperatorTest is Test {
 
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
-        (, uint256 cacheMissAmount1, uint256 maxReportedEpoch1) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        (uint256 cacheMissAmount1, uint256 maxReportedEpoch1) = filBeam.dataSetUsage(DATA_SET_ID_1);
         assertEq(cacheMissAmount1, 2250 * CACHE_MISS_RATE_PER_BYTE);
         assertEq(maxReportedEpoch1, 3);
 
@@ -583,21 +616,20 @@ contract FilBeamOperatorTest is Test {
 
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
-        (uint256 cdnAmount2, uint256 cacheMissAmount2, uint256 maxReportedEpoch2) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount2, 800 * CDN_RATE_PER_BYTE);
+        (uint256 cacheMissAmount2, uint256 maxReportedEpoch2) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 800 * CDN_RATE_PER_BYTE);
         assertEq(cacheMissAmount2, 0);
         assertEq(maxReportedEpoch2, 4);
 
-        assertEq(mockFWSS.getSettlementsCount(), 2);
-
-        (uint256 settledDataSetId1, uint256 settledCdnAmount1, uint256 settledCacheMissAmount1,) =
-            mockFWSS.getSettlement(0);
-        assertEq(settledDataSetId1, DATA_SET_ID_1);
+        // CDN settled once via the shared-rail path, cache miss once via the per-data-set path
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1);
+        (uint256 settledCdnRailId, uint256 settledCdnAmount1,) = mockFWSS.getBandwidthSettlement(0);
+        assertEq(settledCdnRailId, CDN_RAIL_ID_1);
         assertEq(settledCdnAmount1, 450000);
-        assertEq(settledCacheMissAmount1, 0);
 
+        assertEq(mockFWSS.getSettlementsCount(), 1);
         (uint256 settledDataSetId2, uint256 settledCdnAmount2, uint256 settledCacheMissAmount2,) =
-            mockFWSS.getSettlement(1);
+            mockFWSS.getSettlement(0);
         assertEq(settledDataSetId2, DATA_SET_ID_1);
         assertEq(settledCdnAmount2, 0);
         assertEq(settledCacheMissAmount2, 530000);
@@ -610,12 +642,11 @@ contract FilBeamOperatorTest is Test {
         );
 
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        (, uint256 settledCdnAmount1, uint256 settledCacheMissAmount1,) = mockFWSS.getSettlement(0);
+        (, uint256 settledCdnAmount1,) = mockFWSS.getBandwidthSettlement(0);
         assertEq(settledCdnAmount1, 1000 * CDN_RATE_PER_BYTE);
-        assertEq(settledCacheMissAmount1, 0);
 
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        (, uint256 settledCdnAmount2, uint256 settledCacheMissAmount2,) = mockFWSS.getSettlement(1);
+        (, uint256 settledCdnAmount2, uint256 settledCacheMissAmount2,) = mockFWSS.getSettlement(0);
         assertEq(settledCdnAmount2, 0);
         assertEq(settledCacheMissAmount2, 500 * CACHE_MISS_RATE_PER_BYTE);
     }
@@ -641,8 +672,8 @@ contract FilBeamOperatorTest is Test {
         vm.prank(filBeamOperatorController);
         filBeam.recordUsageRollups(1, dataSetIds, cdnBytesUsed, cacheMissBytesUsed);
 
-        (uint256 cdnAmount1, uint256 cacheMissAmount1, uint256 maxEpoch1) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount1, 1000 * CDN_RATE_PER_BYTE);
+        (uint256 cacheMissAmount1, uint256 maxEpoch1) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 1000 * CDN_RATE_PER_BYTE);
         assertEq(cacheMissAmount1, 500 * CACHE_MISS_RATE_PER_BYTE);
         assertEq(maxEpoch1, 1);
 
@@ -652,13 +683,13 @@ contract FilBeamOperatorTest is Test {
             2, _singleUint256Array(DATA_SET_ID_1), _singleUint256Array(2000), _singleUint256Array(1000)
         );
 
-        (uint256 cdnAmount1_v2, uint256 cacheMissAmount1_v2, uint256 maxEpoch1_v2) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount1_v2, 3000 * CDN_RATE_PER_BYTE);
+        (uint256 cacheMissAmount1_v2, uint256 maxEpoch1_v2) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 3000 * CDN_RATE_PER_BYTE);
         assertEq(cacheMissAmount1_v2, 1500 * CACHE_MISS_RATE_PER_BYTE);
         assertEq(maxEpoch1_v2, 2);
 
-        (uint256 cdnAmount2, uint256 cacheMissAmount2, uint256 maxEpoch2) = filBeam.dataSetUsage(DATA_SET_ID_2);
-        assertEq(cdnAmount2, 1500 * CDN_RATE_PER_BYTE);
+        (uint256 cacheMissAmount2, uint256 maxEpoch2) = filBeam.dataSetUsage(DATA_SET_ID_2);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_2), 1500 * CDN_RATE_PER_BYTE);
         assertEq(cacheMissAmount2, 750 * CACHE_MISS_RATE_PER_BYTE);
         assertEq(maxEpoch2, 1);
     }
@@ -760,11 +791,10 @@ contract FilBeamOperatorTest is Test {
 
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
-        assertEq(mockFWSS.getSettlementsCount(), 1);
-        (uint256 dataSetId, uint256 settledCdnAmount, uint256 settledCacheMissAmount,) = mockFWSS.getSettlement(0);
-        assertEq(dataSetId, DATA_SET_ID_1);
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1);
+        (uint256 cdnRailId, uint256 settledCdnAmount,) = mockFWSS.getBandwidthSettlement(0);
+        assertEq(cdnRailId, CDN_RAIL_ID_1);
         assertEq(settledCdnAmount, 300000);
-        assertEq(settledCacheMissAmount, 0);
     }
 
     function test_ReportUsageRollupBatchAtomicity() public {
@@ -788,9 +818,9 @@ contract FilBeamOperatorTest is Test {
         vm.expectRevert(InvalidEpoch.selector);
         filBeam.recordUsageRollups(0, dataSetIds, cdnBytesUsed, cacheMissBytesUsed);
 
-        (uint256 cdnAmount1, uint256 cacheMissAmount1, uint256 maxReportedEpoch1) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        (uint256 cacheMissAmount1, uint256 maxReportedEpoch1) = filBeam.dataSetUsage(DATA_SET_ID_1);
 
-        assertEq(cdnAmount1, 0);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 0);
         assertEq(cacheMissAmount1, 0);
         assertEq(maxReportedEpoch1, 0);
     }
@@ -813,35 +843,32 @@ contract FilBeamOperatorTest is Test {
         dataSetIds[1] = DATA_SET_ID_2;
 
         vm.expectEmit(true, false, false, true);
-        emit CDNSettlement(DATA_SET_ID_1, 300000);
+        emit CDNSettlement(CDN_RAIL_ID_1, 300000);
         vm.expectEmit(true, false, false, true);
-        emit CDNSettlement(DATA_SET_ID_2, 150000);
+        emit CDNSettlement(CDN_RAIL_ID_2, 150000);
 
         vm.prank(user1);
         filBeam.settleCDNPaymentRails(dataSetIds);
 
-        (uint256 cdnAmount1, uint256 cacheMissAmount1, uint256 maxEpoch1) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount1, 0);
+        (uint256 cacheMissAmount1, uint256 maxEpoch1) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 0);
         assertEq(cacheMissAmount1, 1500 * CACHE_MISS_RATE_PER_BYTE);
         assertEq(maxEpoch1, 2);
 
-        (uint256 cdnAmount2, uint256 cacheMissAmount2, uint256 maxEpoch2) = filBeam.dataSetUsage(DATA_SET_ID_2);
-        assertEq(cdnAmount2, 0);
+        (uint256 cacheMissAmount2, uint256 maxEpoch2) = filBeam.dataSetUsage(DATA_SET_ID_2);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_2), 0);
         assertEq(cacheMissAmount2, 750 * CACHE_MISS_RATE_PER_BYTE);
         assertEq(maxEpoch2, 1);
 
-        assertEq(mockFWSS.getSettlementsCount(), 2);
-        (uint256 settledDataSetId1, uint256 settledCdnAmount1, uint256 settledCacheMissAmount1,) =
-            mockFWSS.getSettlement(0);
-        assertEq(settledDataSetId1, DATA_SET_ID_1);
+        // Distinct rails settle independently via the shared-rail path
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 2);
+        (uint256 settledCdnRailId1, uint256 settledCdnAmount1,) = mockFWSS.getBandwidthSettlement(0);
+        assertEq(settledCdnRailId1, CDN_RAIL_ID_1);
         assertEq(settledCdnAmount1, 300000);
-        assertEq(settledCacheMissAmount1, 0);
 
-        (uint256 settledDataSetId2, uint256 settledCdnAmount2, uint256 settledCacheMissAmount2,) =
-            mockFWSS.getSettlement(1);
-        assertEq(settledDataSetId2, DATA_SET_ID_2);
+        (uint256 settledCdnRailId2, uint256 settledCdnAmount2,) = mockFWSS.getBandwidthSettlement(1);
+        assertEq(settledCdnRailId2, CDN_RAIL_ID_2);
         assertEq(settledCdnAmount2, 150000);
-        assertEq(settledCacheMissAmount2, 0);
     }
 
     function test_SettleCacheMissPaymentRailBatch() public {
@@ -869,13 +896,13 @@ contract FilBeamOperatorTest is Test {
         vm.prank(user1);
         filBeam.settleCacheMissPaymentRails(dataSetIds);
 
-        (uint256 cdnAmount1, uint256 cacheMissAmount1, uint256 maxEpoch1) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount1, 3000 * CDN_RATE_PER_BYTE);
+        (uint256 cacheMissAmount1, uint256 maxEpoch1) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 3000 * CDN_RATE_PER_BYTE);
         assertEq(cacheMissAmount1, 0);
         assertEq(maxEpoch1, 2);
 
-        (uint256 cdnAmount2, uint256 cacheMissAmount2, uint256 maxEpoch2) = filBeam.dataSetUsage(DATA_SET_ID_2);
-        assertEq(cdnAmount2, 1500 * CDN_RATE_PER_BYTE);
+        (uint256 cacheMissAmount2, uint256 maxEpoch2) = filBeam.dataSetUsage(DATA_SET_ID_2);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_2), 1500 * CDN_RATE_PER_BYTE);
         assertEq(cacheMissAmount2, 0);
         assertEq(maxEpoch2, 1);
 
@@ -896,7 +923,7 @@ contract FilBeamOperatorTest is Test {
     function test_SettleCDNPaymentRailBatchEmptyArray() public {
         uint256[] memory dataSetIds = new uint256[](0);
         filBeam.settleCDNPaymentRails(dataSetIds);
-        assertEq(mockFWSS.getSettlementsCount(), 0);
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 0);
     }
 
     function test_SettleCacheMissPaymentRailBatchEmptyArray() public {
@@ -911,7 +938,7 @@ contract FilBeamOperatorTest is Test {
 
         // Should not revert, just return early without settlements
         filBeam.settleCDNPaymentRails(dataSetIds);
-        assertEq(mockFWSS.getSettlementsCount(), 0);
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 0);
     }
 
     function test_SettleCacheMissPaymentRailBatchDataSetNotInitialized() public {
@@ -929,14 +956,14 @@ contract FilBeamOperatorTest is Test {
             1, _singleUint256Array(DATA_SET_ID_1), _singleUint256Array(1000), _singleUint256Array(500)
         );
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        assertEq(mockFWSS.getSettlementsCount(), 1);
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1);
 
         uint256[] memory dataSetIds = new uint256[](1);
         dataSetIds[0] = DATA_SET_ID_1;
 
         // Should not revert, just return early without new settlements
         filBeam.settleCDNPaymentRails(dataSetIds);
-        assertEq(mockFWSS.getSettlementsCount(), 1); // Still 1, no new settlement
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1); // Still 1, no new settlement
     }
 
     function test_SettleCacheMissPaymentRailBatchNoUsageToSettle() public {
@@ -957,9 +984,12 @@ contract FilBeamOperatorTest is Test {
 
     function test_SilentEarlyReturnsNoEvents() public {
         // Test 1: Uninitialized dataset should not revert or change state
+        uint256 initialBandwidthCount = mockFWSS.getBandwidthSettlementsCount();
         uint256 initialSettlementCount = mockFWSS.getSettlementsCount();
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        assertEq(mockFWSS.getSettlementsCount(), initialSettlementCount, "Should not settle uninitialized dataset");
+        assertEq(
+            mockFWSS.getBandwidthSettlementsCount(), initialBandwidthCount, "Should not settle uninitialized dataset"
+        );
 
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_1));
         assertEq(mockFWSS.getSettlementsCount(), initialSettlementCount, "Should not settle uninitialized dataset");
@@ -972,11 +1002,13 @@ contract FilBeamOperatorTest is Test {
 
         // Settle once (should work)
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        assertEq(mockFWSS.getSettlementsCount(), initialSettlementCount + 1, "Should settle first time");
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), initialBandwidthCount + 1, "Should settle first time");
 
         // Test 2: Already settled dataset should not create new settlements
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        assertEq(mockFWSS.getSettlementsCount(), initialSettlementCount + 1, "Should not settle when no new usage");
+        assertEq(
+            mockFWSS.getBandwidthSettlementsCount(), initialBandwidthCount + 1, "Should not settle when no new usage"
+        );
     }
 
     function test_SettlementBatchMixedInitialization() public {
@@ -994,12 +1026,12 @@ contract FilBeamOperatorTest is Test {
         filBeam.settleCDNPaymentRails(dataSetIds);
 
         // Verify DATA_SET_ID_1 was settled
-        (uint256 cdnAmount1, uint256 cacheMissAmount1, uint256 maxEpoch1) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount1, 0); // Settled, so amount is 0
+        (uint256 cacheMissAmount1, uint256 maxEpoch1) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 0); // Settled, so amount is 0
         assertEq(cacheMissAmount1, 500 * CACHE_MISS_RATE_PER_BYTE); // Not settled yet
         assertEq(maxEpoch1, 1);
 
-        assertEq(mockFWSS.getSettlementsCount(), 1); // Only DATA_SET_ID_1 was settled
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1); // Only DATA_SET_ID_1 was settled
     }
 
     function test_SetFilBeamController() public {
@@ -1042,8 +1074,7 @@ contract FilBeamOperatorTest is Test {
             1, _singleUint256Array(DATA_SET_ID_1), _singleUint256Array(1000), _singleUint256Array(500)
         );
 
-        (uint256 cdnAmount,,) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount, 1000 * CDN_RATE_PER_BYTE);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 1000 * CDN_RATE_PER_BYTE);
     }
 
     // Test settling accumulated amounts without new usage
@@ -1062,7 +1093,8 @@ contract FilBeamOperatorTest is Test {
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
         // Verify initial settlements
-        assertEq(mockFWSS.getSettlementsCount(), 2);
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1);
+        assertEq(mockFWSS.getSettlementsCount(), 1);
 
         // Manually add accumulated amounts (simulating partial settlement scenario)
         // This would happen if the previous settlement was limited by lockupFixed
@@ -1078,16 +1110,15 @@ contract FilBeamOperatorTest is Test {
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
         // Verify CDN was settled
-        assertEq(mockFWSS.getSettlementsCount(), 3);
-        (uint256 cdnAmount,,) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount, 0, "CDN amount should be fully settled");
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 2);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 0, "CDN amount should be fully settled");
 
         // Settle cache miss without new usage report
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
         // Verify cache miss was settled
-        assertEq(mockFWSS.getSettlementsCount(), 4);
-        (, uint256 cacheMissAmount,) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        assertEq(mockFWSS.getSettlementsCount(), 2);
+        (uint256 cacheMissAmount,) = filBeam.dataSetUsage(DATA_SET_ID_1);
         assertEq(cacheMissAmount, 0, "Cache miss amount should be fully settled");
     }
 
@@ -1116,14 +1147,14 @@ contract FilBeamOperatorTest is Test {
 
         // Try to settle - should not revert or settle
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_2));
-        assertEq(mockFWSS.getSettlementsCount(), 0, "Should not settle without rail");
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 0, "Should not settle without rail");
 
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_2));
         assertEq(mockFWSS.getSettlementsCount(), 0, "Should not settle without rail");
 
-        // Amount should still be accumulated
-        (uint256 cdnAmount, uint256 cacheMissAmount,) = filBeam.dataSetUsage(DATA_SET_ID_2);
-        assertEq(cdnAmount, 100000, "Amount should still be accumulated");
+        // Amount should still be accumulated (bandwidth lands on rail id 0 with no rail configured)
+        (uint256 cacheMissAmount,) = filBeam.dataSetUsage(DATA_SET_ID_2);
+        assertEq(filBeam.cdnRailAmount(0), 100000, "Amount should still be accumulated");
         assertEq(cacheMissAmount, 100000, "Amount should still be accumulated");
     }
 
@@ -1143,55 +1174,54 @@ contract FilBeamOperatorTest is Test {
         );
 
         // Check accumulated amounts
-        (uint256 cdnAmount1, uint256 cacheMissAmount1,) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount1, 100000, "Should have 100k CDN amount");
+        (uint256 cacheMissAmount1,) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 100000, "Should have 100k CDN amount");
         assertEq(cacheMissAmount1, 100000, "Should have 100k cache miss amount");
 
         // First CDN settlement - should only settle 50k due to lockup limit
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
         // Check remaining amount after partial settlement
-        (uint256 cdnAmount2, uint256 cacheMissAmount2,) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount2, 50000, "Should have 50k CDN remaining after partial settlement");
+        (uint256 cacheMissAmount2,) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 50000, "Should have 50k CDN remaining after partial settlement");
         assertEq(cacheMissAmount2, 100000, "Cache miss amount should be unchanged");
 
         // Verify settlement amount
-        assertEq(mockFWSS.getSettlementsCount(), 1);
-        (, uint256 settledCdn1,,) = mockFWSS.getSettlement(0);
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1);
+        (, uint256 settledCdn1,) = mockFWSS.getBandwidthSettlement(0);
         assertEq(settledCdn1, 50000, "Should have settled 50k CDN");
 
         // First cache miss settlement - should only settle 30k due to lockup limit
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
         // Check remaining amount after partial settlement
-        (uint256 cdnAmount3, uint256 cacheMissAmount3,) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount3, 50000, "CDN amount should be unchanged");
+        (uint256 cacheMissAmount3,) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 50000, "CDN amount should be unchanged");
         assertEq(cacheMissAmount3, 70000, "Should have 70k cache miss remaining after partial settlement");
 
         // Verify settlement amount
-        assertEq(mockFWSS.getSettlementsCount(), 2);
-        (,, uint256 settledCacheMiss1,) = mockFWSS.getSettlement(1);
+        assertEq(mockFWSS.getSettlementsCount(), 1);
+        (,, uint256 settledCacheMiss1,) = mockFWSS.getSettlement(0);
         assertEq(settledCacheMiss1, 30000, "Should have settled 30k cache miss");
 
         // Second CDN settlement - should settle remaining 50k
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
-        (uint256 cdnAmount4,,) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount4, 0, "Should have no CDN remaining after second settlement");
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 0, "Should have no CDN remaining after second settlement");
 
-        assertEq(mockFWSS.getSettlementsCount(), 3);
-        (, uint256 settledCdn2,,) = mockFWSS.getSettlement(2);
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 2);
+        (, uint256 settledCdn2,) = mockFWSS.getBandwidthSettlement(1);
         assertEq(settledCdn2, 50000, "Should have settled remaining 50k CDN");
 
         // Increase lockup and settle remaining cache miss
         mockPayments.setLockupFixed(2, 100000); // Increase cache miss rail lockup
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
-        (, uint256 cacheMissAmount4,) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        (uint256 cacheMissAmount4,) = filBeam.dataSetUsage(DATA_SET_ID_1);
         assertEq(cacheMissAmount4, 0, "Should have no cache miss remaining");
 
-        assertEq(mockFWSS.getSettlementsCount(), 4);
-        (,, uint256 settledCacheMiss2,) = mockFWSS.getSettlement(3);
+        assertEq(mockFWSS.getSettlementsCount(), 2);
+        (,, uint256 settledCacheMiss2,) = mockFWSS.getSettlement(1);
         assertEq(settledCacheMiss2, 70000, "Should have settled remaining 70k cache miss");
     }
 
@@ -1207,11 +1237,10 @@ contract FilBeamOperatorTest is Test {
 
         // Try to settle - should not settle anything due to zero lockup
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        assertEq(mockFWSS.getSettlementsCount(), 0, "Should not settle with zero lockup");
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 0, "Should not settle with zero lockup");
 
         // Amount should still be accumulated
-        (uint256 cdnAmount,,) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount, 100000, "Amount should still be accumulated");
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 100000, "Amount should still be accumulated");
     }
 
     function test_SettlementWithInactiveRail() public {
@@ -1229,18 +1258,16 @@ contract FilBeamOperatorTest is Test {
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
         // Amount should still be accumulated
-        (uint256 cdnAmount,,) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount, 100000, "Amount should still be accumulated");
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 100000, "Amount should still be accumulated");
 
         // Reactivate rail and verify settlement works
         mockPayments.setRailExists(1, true);
         mockPayments.setLockupFixed(1, 100000);
 
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        assertEq(mockFWSS.getSettlementsCount(), 1, "Should settle after reactivation");
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1, "Should settle after reactivation");
 
-        (uint256 cdnAmountAfter,,) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmountAfter, 0, "Amount should be settled");
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 0, "Amount should be settled");
     }
 
     // Test multiple partial settlements without new usage
@@ -1258,9 +1285,10 @@ contract FilBeamOperatorTest is Test {
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
-        assertEq(mockFWSS.getSettlementsCount(), 2);
-        (uint256 cdnAmount1, uint256 cacheMissAmount1,) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount1, 0, "CDN amount should be 0 after first settlement");
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1);
+        assertEq(mockFWSS.getSettlementsCount(), 1);
+        (uint256 cacheMissAmount1,) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 0, "CDN amount should be 0 after first settlement");
         assertEq(cacheMissAmount1, 0, "Cache miss amount should be 0 after first settlement");
 
         // Simulate accumulated amounts from a partial settlement
@@ -1276,26 +1304,28 @@ contract FilBeamOperatorTest is Test {
 
         // Second settlement - should settle new amounts
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        assertEq(mockFWSS.getSettlementsCount(), 3);
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 2);
 
         // Try to settle CDN again without new usage - should not create new settlement
-        uint256 settlementCountBefore = mockFWSS.getSettlementsCount();
+        uint256 bandwidthCountBefore = mockFWSS.getBandwidthSettlementsCount();
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        assertEq(mockFWSS.getSettlementsCount(), settlementCountBefore, "Should not settle when no amount");
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), bandwidthCountBefore, "Should not settle when no amount");
 
         // Settle cache miss
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        assertEq(mockFWSS.getSettlementsCount(), 4);
+        assertEq(mockFWSS.getSettlementsCount(), 2);
 
         // Verify final state
-        (uint256 cdnAmount2, uint256 cacheMissAmount2,) = filBeam.dataSetUsage(DATA_SET_ID_1);
-        assertEq(cdnAmount2, 0, "CDN amount should be 0 after all settlements");
+        (uint256 cacheMissAmount2,) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 0, "CDN amount should be 0 after all settlements");
         assertEq(cacheMissAmount2, 0, "Cache miss amount should be 0 after all settlements");
 
         // Try settling again - should not create new settlements
+        uint256 finalBandwidthCount = mockFWSS.getBandwidthSettlementsCount();
         uint256 finalCount = mockFWSS.getSettlementsCount();
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(DATA_SET_ID_1));
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), finalBandwidthCount, "No new settlements when no amount");
         assertEq(mockFWSS.getSettlementsCount(), finalCount, "No new settlements when no amount");
     }
 
@@ -1326,13 +1356,15 @@ contract FilBeamOperatorTest is Test {
 
         // Try to settle - should not revert or settle
         uint256 settlementCountBefore = mockFWSS.getSettlementsCount();
+        uint256 bandwidthCountBefore = mockFWSS.getBandwidthSettlementsCount();
         filBeam.settleCDNPaymentRails(_singleUint256Array(dataSetId3));
         filBeam.settleCacheMissPaymentRails(_singleUint256Array(dataSetId3));
         assertEq(mockFWSS.getSettlementsCount(), settlementCountBefore, "Should not settle with rail ID 0");
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), bandwidthCountBefore, "Should not settle with rail ID 0");
 
-        // Amount should still be accumulated
-        (uint256 cdnAmount, uint256 cacheMissAmount,) = filBeam.dataSetUsage(dataSetId3);
-        assertEq(cdnAmount, 100000, "CDN amount should still be accumulated");
+        // Amount should still be accumulated (bandwidth lands on rail id 0 with no rail configured)
+        (uint256 cacheMissAmount,) = filBeam.dataSetUsage(dataSetId3);
+        assertEq(filBeam.cdnRailAmount(0), 100000, "CDN amount should still be accumulated");
         assertEq(cacheMissAmount, 100000, "Cache miss amount should still be accumulated");
     }
 
@@ -1436,7 +1468,7 @@ contract FilBeamOperatorTest is Test {
         newOperator.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
         // Verify settlement was successful
-        assertGt(mockFWSS.getSettlementsCount(), 0, "Settlement should have occurred");
+        assertGt(mockFWSS.getBandwidthSettlementsCount(), 0, "Settlement should have occurred");
     }
 
     function test_TransferFwssFilBeamController_IntegrationFlow() public {
@@ -1458,7 +1490,7 @@ contract FilBeamOperatorTest is Test {
 
         // 2. Settle partially with old operator (this works)
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
-        uint256 settlementCountBefore = mockFWSS.getSettlementsCount();
+        uint256 bandwidthCountBefore = mockFWSS.getBandwidthSettlementsCount();
 
         // 3. Old operator records more usage (to have accumulated amount after migration)
         vm.prank(filBeamOperatorController);
@@ -1480,10 +1512,129 @@ contract FilBeamOperatorTest is Test {
         newOperator.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
 
         // Verify settlements occurred
-        assertGt(mockFWSS.getSettlementsCount(), settlementCountBefore, "New settlement should have occurred");
+        assertGt(mockFWSS.getBandwidthSettlementsCount(), bandwidthCountBefore, "New settlement should have occurred");
 
         // 7. Old operator cannot settle anymore (has accumulated amount but can't settle to FWSS)
         vm.expectRevert(MockFWSS.UnauthorizedCaller.selector);
         filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
+    }
+
+    // ============ Shared CDN bandwidth rail (subscription) tests ============
+
+    /// @dev Points DATA_SET_ID_2 at the same shared bandwidth rail as DATA_SET_ID_1, while
+    /// keeping its own cache miss rail. This mirrors a multi-copy upload that joins one CDN
+    /// subscription.
+    function _shareCdnRail() internal {
+        FilecoinWarmStorageService.DataSetInfoView memory dsInfo2 = FilecoinWarmStorageService.DataSetInfoView({
+            pdpRailId: 0,
+            cacheMissRailId: CACHE_MISS_RAIL_ID_2,
+            cdnRailId: CDN_RAIL_ID_1, // shared with DATA_SET_ID_1
+            payer: user1,
+            payee: user2,
+            serviceProvider: address(0),
+            commissionBps: 0,
+            clientDataSetId: 0,
+            pdpEndEpoch: 0,
+            providerId: 0,
+            dataSetId: DATA_SET_ID_2
+        });
+        mockStateView.setDataSetInfo(DATA_SET_ID_2, dsInfo2);
+    }
+
+    function test_SharedRailAccumulatesBandwidthOntoOneRail() public {
+        _shareCdnRail();
+
+        uint256[] memory dataSetIds = new uint256[](2);
+        uint256[] memory cdnBytesUsed = new uint256[](2);
+        uint256[] memory cacheMissBytesUsed = new uint256[](2);
+        dataSetIds[0] = DATA_SET_ID_1;
+        cdnBytesUsed[0] = 1000;
+        cacheMissBytesUsed[0] = 500;
+        dataSetIds[1] = DATA_SET_ID_2;
+        cdnBytesUsed[1] = 1500;
+        cacheMissBytesUsed[1] = 750;
+
+        vm.prank(filBeamOperatorController);
+        filBeam.recordUsageRollups(1, dataSetIds, cdnBytesUsed, cacheMissBytesUsed);
+
+        // Bandwidth from both data sets collapses onto the shared rail
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 2500 * CDN_RATE_PER_BYTE);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_2), 0);
+
+        // Cache miss stays per data set
+        (uint256 cacheMissAmount1,) = filBeam.dataSetUsage(DATA_SET_ID_1);
+        (uint256 cacheMissAmount2,) = filBeam.dataSetUsage(DATA_SET_ID_2);
+        assertEq(cacheMissAmount1, 500 * CACHE_MISS_RATE_PER_BYTE);
+        assertEq(cacheMissAmount2, 750 * CACHE_MISS_RATE_PER_BYTE);
+    }
+
+    function test_SharedRailSettlesBandwidthOnceWithSummedAmount() public {
+        _shareCdnRail();
+
+        uint256[] memory dataSetIds = new uint256[](2);
+        uint256[] memory cdnBytesUsed = new uint256[](2);
+        uint256[] memory cacheMissBytesUsed = new uint256[](2);
+        dataSetIds[0] = DATA_SET_ID_1;
+        cdnBytesUsed[0] = 1000;
+        cacheMissBytesUsed[0] = 500;
+        dataSetIds[1] = DATA_SET_ID_2;
+        cdnBytesUsed[1] = 1500;
+        cacheMissBytesUsed[1] = 750;
+
+        vm.prank(filBeamOperatorController);
+        filBeam.recordUsageRollups(1, dataSetIds, cdnBytesUsed, cacheMissBytesUsed);
+
+        // The shared rail is settled exactly once with the summed amount, even though both
+        // data sets are passed in.
+        vm.expectEmit(true, false, false, true);
+        emit CDNSettlement(CDN_RAIL_ID_1, 2500 * CDN_RATE_PER_BYTE);
+
+        filBeam.settleCDNPaymentRails(dataSetIds);
+
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1, "bandwidth settled once for the shared rail");
+        (uint256 cdnRailId, uint256 settledCdnAmount,) = mockFWSS.getBandwidthSettlement(0);
+        assertEq(cdnRailId, CDN_RAIL_ID_1);
+        assertEq(settledCdnAmount, 2500 * CDN_RATE_PER_BYTE);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 0);
+
+        // Cache miss settles per data set: two settlements, one per provider rail
+        filBeam.settleCacheMissPaymentRails(dataSetIds);
+        assertEq(mockFWSS.getSettlementsCount(), 2, "cache miss settled per data set");
+
+        (uint256 settledDataSetId1,, uint256 settledCacheMiss1,) = mockFWSS.getSettlement(0);
+        assertEq(settledDataSetId1, DATA_SET_ID_1);
+        assertEq(settledCacheMiss1, 500 * CACHE_MISS_RATE_PER_BYTE);
+
+        (uint256 settledDataSetId2,, uint256 settledCacheMiss2,) = mockFWSS.getSettlement(1);
+        assertEq(settledDataSetId2, DATA_SET_ID_2);
+        assertEq(settledCacheMiss2, 750 * CACHE_MISS_RATE_PER_BYTE);
+    }
+
+    function test_SharedRailSettlesOnceWhenOnlyOneMemberPassed() public {
+        _shareCdnRail();
+
+        uint256[] memory dataSetIds = new uint256[](2);
+        uint256[] memory cdnBytesUsed = new uint256[](2);
+        uint256[] memory cacheMissBytesUsed = new uint256[](2);
+        dataSetIds[0] = DATA_SET_ID_1;
+        cdnBytesUsed[0] = 1000;
+        cacheMissBytesUsed[0] = 500;
+        dataSetIds[1] = DATA_SET_ID_2;
+        cdnBytesUsed[1] = 1500;
+        cacheMissBytesUsed[1] = 750;
+
+        vm.prank(filBeamOperatorController);
+        filBeam.recordUsageRollups(1, dataSetIds, cdnBytesUsed, cacheMissBytesUsed);
+
+        // Settling just one member of the subscription drains the whole shared rail
+        filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_2));
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1);
+        (, uint256 settledCdnAmount,) = mockFWSS.getBandwidthSettlement(0);
+        assertEq(settledCdnAmount, 2500 * CDN_RATE_PER_BYTE);
+        assertEq(filBeam.cdnRailAmount(CDN_RAIL_ID_1), 0);
+
+        // Settling the sibling afterwards is a no-op for bandwidth
+        filBeam.settleCDNPaymentRails(_singleUint256Array(DATA_SET_ID_1));
+        assertEq(mockFWSS.getBandwidthSettlementsCount(), 1, "no second bandwidth settlement");
     }
 }

--- a/tools/settle-cache-miss-egress.sh
+++ b/tools/settle-cache-miss-egress.sh
@@ -45,14 +45,14 @@ for dataset_id in "${INPUT_IDS[@]}"; do
     # Trim whitespace
     dataset_id=$(echo "$dataset_id" | tr -d '[:space:]')
 
-    # Call dataSetUsage(uint256) -> (uint256 cdnAmount, uint256 cacheMissAmount, uint256 maxReportedEpoch)
-    USAGE_RAW=$(cast call "$FILBEAM_OPERATOR_ADDRESS" "dataSetUsage(uint256)(uint256,uint256,uint256)" "$dataset_id" --rpc-url "$RPC_URL" 2>&1) || {
+    # Call dataSetUsage(uint256) -> (uint256 cacheMissAmount, uint256 maxReportedEpoch)
+    USAGE_RAW=$(cast call "$FILBEAM_OPERATOR_ADDRESS" "dataSetUsage(uint256)(uint256,uint256)" "$dataset_id" --rpc-url "$RPC_URL" 2>&1) || {
         echo "  Dataset $dataset_id: failed to query usage, skipping."
         continue
     }
 
-    # Parse cacheMissAmount (2nd line)
-    CACHE_MISS_AMOUNT=$(echo "$USAGE_RAW" | sed -n '2p' | awk '{print $1}')
+    # Parse cacheMissAmount (1st line)
+    CACHE_MISS_AMOUNT=$(echo "$USAGE_RAW" | sed -n '1p' | awk '{print $1}')
 
     if [ ! -z "$CACHE_MISS_AMOUNT" ] && [ "$CACHE_MISS_AMOUNT" -gt 0 ] 2>/dev/null; then
         echo "  Dataset $dataset_id: unsettled cache-miss amount = $CACHE_MISS_AMOUNT"


### PR DESCRIPTION
## What

Updates `FilBeamOperator` so CDN bandwidth is metered and settled per shared bandwidth rail (the CDN subscription) instead of per data set, while cache-miss stays per data set.

Full proposal, with rationale and the companion changes in the other repos: https://gist.github.com/juliangruber/a34b225f9588ec68d069054d731e20c9

The gist also links to the companion draft PRs in `FilOzone/filecoin-services`, `FilOzone/synapse-sdk`, and `filbeam/worker`.

## Why

Multi-copy upload stores a piece in 2 data sets on 2 providers. When CDN is enabled on both, the bandwidth service was bought twice. FWSS now lets data sets share one bandwidth rail keyed by `(payer, group)`, and exposes `settleCDNBandwidthRail(cdnRailId, cdnAmount)` to settle that shared rail once. The shared `cdnRailId` is the subscription identity, so the operator aggregates and settles bandwidth by rail id.

## How

- Bandwidth usage accumulates in `cdnRailAmount[cdnRailId]`, resolved from `FilecoinWarmStorageServiceStateView.getDataSet(dataSetId).cdnRailId` at record time. Cache-miss stays in `dataSetUsage[dataSetId]`.
- `settleCDNBandwidthRails(uint256[] cdnRailIds)` is the canonical bandwidth settlement path, it settles each shared rail once with its aggregated amount via FWSS `settleCDNBandwidthRail`. This is what the FilBeam worker calls with the distinct rail ids it has metered.
- `settleCDNPaymentRails(uint256[] dataSetIds)` is kept as a convenience that resolves each data set to its rail first, both paths share one internal settle-by-rail-id helper.
- Cache-miss is settled per data set via FWSS `settleFilBeamPaymentRails(dataSetId, 0, cacheMissAmount)`, with `cdnAmount` always 0 so the bandwidth portion is never double-settled.
- `CDNSettlement` is keyed by `cdnRailId`, `CacheMissSettlement` stays keyed by `dataSetId`. `MockFWSS` gains `settleCDNBandwidthRail`.

## Cross-repo interface

The wire ABI the `filbeam/worker` PR targets:

- `recordUsageRollups(uint256 toEpoch, uint256[] dataSetIds, uint256[] cdnBytesUsed, uint256[] cacheMissBytesUsed)` - usage reported per data set, the contract resolves and aggregates bandwidth onto the shared rail.
- `settleCDNBandwidthRails(uint256[] cdnRailIds)` - bandwidth, once per rail.
- `settleCacheMissPaymentRails(uint256[] dataSetIds)` - cache-miss, per data set.

## Reviewer notes

The real FWSS must expose `settleCDNBandwidthRail(uint256,uint256)` callable by the FilBeam controller, see the companion `filecoin-services` PR. Called here through a minimal local `IFilBeamBandwidthSettlement` interface against `fwssContractAddress`.

## Follow-ups

These are intentionally out of scope for this draft.

- Consider collapsing `settleCDNPaymentRails` (by data set) into `settleCDNBandwidthRails` (by rail) once downstream settles by rail id everywhere.
- Per-rail replay guard for bandwidth recording, mirroring the per-data-set `maxReportedEpoch` guard.
