### PR TITLE
ci: add issues and PRs to the FOC project board

### DIFF
--- a/.github/workflows/add-issues-and-prs-to-foc-project-board.yml
+++ b/.github/workflows/add-issues-and-prs-to-foc-project-board.yml
@@ -1,0 +1,41 @@
+######################################################################################
+# READ THIS FIRST
+# This file is authored in FilOzone/github-mgmt repository and MANUALLY copied to other repos.
+# See https://github.com/FilOzone/github-mgmt/blob/master/files/workflows/add-issues-and-prs-to-foc-project-board.yml for more info.
+######################################################################################
+
+# This action adds all issues and PRs to the FOC project board.
+# It is used to keep the project board up to date with the issues and PRs.
+# It is triggered by the issue and PR events.
+# It assumes a `FILOZZY_CI_ADD_TO_PROJECT` secret is set in the repo.
+# This secret should have the permissions outlined in https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository
+name: Add issues and PRs to FOC project board
+
+on:
+  issues:
+    types:
+      - opened
+  # Using "pull_request_target" instead of "pull_request" to support PRs from forks.
+  # pull_request_target has access to secrets even for fork PRs, which is necessary
+  # for this action to authenticate and add items to the project board.
+  # pull_request_target runs the workflow file from the base branch (main),
+  # not from the PR branch, so attackers cannot modify this workflow via PR.
+  # This action does not check out nor execute user code so we should be safe.
+  # We also hardcode to specific hash to ensure no unintended changes underneath us.
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add all issues and PRs to project
+    # This job authenticates with the dedicated FILOZZY_CI_ADD_TO_PROJECT PAT and does
+    # not use the default GITHUB_TOKEN, so drop all of its permissions to limit blast radius.
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
+        continue-on-error: true # Don't fail if item already exists in project. actions/add-to-project does not currently handle this case gracefully.
+        with:
+          project-url: https://github.com/orgs/FilOzone/projects/14
+          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}


### PR DESCRIPTION
## What

Adds the canonical FilOzone workflow that auto-adds newly opened **issues and PRs** to the **FOC board** ([FilOzone org project #14](https://github.com/orgs/FilOzone/projects/14)) — matching how the FOC repos and `filbeam/worker` do it.

Uses the `FILOZZY_CI_ADD_TO_PROJECT` org secret (now created in the filbeam org), the same secret the FOC repos use. Pinned `actions/add-to-project@v2.0.0`, `pull_request_target` (covers fork/dependabot PRs), `continue-on-error`, and `permissions: {}`. The file is byte-identical to the FOC canonical template.

Part of filbeam/worker#695
